### PR TITLE
feat: Implement bot settings page

### DIFF
--- a/web/application/config/config.php
+++ b/web/application/config/config.php
@@ -384,7 +384,7 @@ $config['encryption_key'] = '';
 |
 */
 $config['sess_driver'] = 'files';
-$config['sess_cookie_name'] = 'ci_session';
+$config['sess_cookie_name'] = 'PHPSESSID';
 $config['sess_samesite'] = 'Lax';
 $config['sess_expiration'] = 7200;
 $config['sess_save_path'] = NULL;

--- a/web/application/config/routes.php
+++ b/web/application/config/routes.php
@@ -3,5 +3,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 $route['default_controller'] = 'dashboard';
 $route['bot'] = 'bot';
+$route['settings'] = 'settings';
+$route['settings/update'] = 'settings/update';
 $route['404_override'] = '';
 $route['translate_uri_dashes'] = FALSE;

--- a/web/application/controllers/Bot.php
+++ b/web/application/controllers/Bot.php
@@ -1,19 +1,14 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-class Bot extends CI_Controller {
+class Bot extends MY_Controller {
 
     public function __construct()
     {
         parent::__construct();
-        $this->load->model('user_model');
-
-        // Hardcoded user_id for now
-        $user_id = 1;
-        $user = $this->user_model->get_user($user_id);
 
         // Check if user is an admin
-        if (!isset($user->role) || $user->role !== 'admin') {
+        if ($this->role !== 'admin') {
             redirect('dashboard');
         }
     }

--- a/web/application/controllers/Dashboard.php
+++ b/web/application/controllers/Dashboard.php
@@ -1,7 +1,7 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-class Dashboard extends CI_Controller {
+class Dashboard extends MY_Controller {
 
     public function __construct()
     {
@@ -11,37 +11,25 @@ class Dashboard extends CI_Controller {
 
     public function index()
     {
-        // Hardcoded user_id for now
-        $user_id = 1;
-
-        $data['user'] = $this->user_model->get_user($user_id);
+        $data['user'] = $this->user_model->get_user($this->user_id);
         $this->load->view('dashboard', $data);
     }
 
     public function koleksi()
     {
-        // Hardcoded user_id for now
-        $user_id = 1;
-
-        $data['content'] = $this->user_model->get_user_content($user_id);
+        $data['content'] = $this->user_model->get_user_content($this->user_id);
         $this->load->view('koleksi', $data);
     }
 
     public function riwayat()
     {
-        // Hardcoded user_id for now
-        $user_id = 1;
-
-        $data['history'] = $this->user_model->get_purchase_history($user_id);
+        $data['history'] = $this->user_model->get_purchase_history($this->user_id);
         $this->load->view('riwayat', $data);
     }
 
     public function saldo()
     {
-        // Hardcoded user_id for now
-        $user_id = 1;
-
-        $data['user'] = $this->user_model->get_user($user_id);
+        $data['user'] = $this->user_model->get_user($this->user_id);
         $this->load->view('saldo', $data);
     }
 }

--- a/web/application/controllers/Settings.php
+++ b/web/application/controllers/Settings.php
@@ -1,0 +1,65 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Settings extends MY_Controller {
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        // Check if user is an admin
+        if ($this->role !== 'admin') {
+            redirect('dashboard');
+        }
+
+        // Load helpers
+        $this->load->helper('url');
+        $this->load->helper('form');
+        $this->load->helper('config');
+    }
+
+    public function index()
+    {
+        $data['config'] = get_config_values();
+        $this->load->view('settings', $data);
+    }
+
+    public function update()
+    {
+        // In a real app, you'd do more robust validation here
+        $new_config = [
+            'BOT_TOKEN' => $this->input->post('bot_token'),
+            'PUBLIC_CHANNEL_USERNAME' => $this->input->post('public_channel_username')
+        ];
+
+        // This is a simplified update. A more robust solution would be needed for a complex config file.
+        $config_file_path = FCPATH . '../config/config.php';
+        $config_file_content = file_get_contents($config_file_path);
+
+        foreach ($new_config as $key => $value) {
+            $config_file_content = preg_replace(
+                "/define\s*\(\s*'$key'\s*,\s*'.*?'\s*\)/",
+                "define('$key', '$value')",
+                $config_file_content
+            );
+        }
+
+        file_put_contents($config_file_path, $config_file_content);
+
+        // Set the webhook
+        $webhook_url = $this->input->post('webhook_url');
+        $bot_token = $this->input->post('bot_token');
+        $telegram_api_url = "https://api.telegram.org/bot{$bot_token}/setWebhook?url={$webhook_url}";
+
+        // Using cURL to send the request
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $telegram_api_url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        // We can add a session flash message to show the result
+        // For now, just redirect back to the settings page
+        redirect('settings');
+    }
+}

--- a/web/application/core/MY_Controller.php
+++ b/web/application/core/MY_Controller.php
@@ -1,0 +1,26 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class MY_Controller extends CI_Controller {
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->load->helper('url');
+
+        // Since the auth is handled outside CI, we check the session directly.
+        if (session_status() == PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        if (empty($_SESSION['user_id'])) {
+            // The root index.php has the login button.
+            redirect('/');
+        }
+
+        // Make user data available to all controllers that extend MY_Controller
+        $this->user_id = $_SESSION['user_id'];
+        $this->username = $_SESSION['username'];
+        $this->role = $_SESSION['role'];
+    }
+}

--- a/web/application/helpers/config_helper.php
+++ b/web/application/helpers/config_helper.php
@@ -1,0 +1,24 @@
+<?php
+if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+if (!function_exists('get_config_values')) {
+    function get_config_values() {
+        $config_file_path = FCPATH . '../config/config.php';
+
+        if (!file_exists($config_file_path)) {
+            return false;
+        }
+
+        $config_file_content = file_get_contents($config_file_path);
+
+        $config = [];
+        $pattern = '/define\s*\(\s*\'([A-Z_]+)\'\s*,\s*\'(.*?)\'\s*\)/';
+        preg_match_all($pattern, $config_file_content, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $config[$match[1]] = $match[2];
+        }
+
+        return $config;
+    }
+}

--- a/web/application/views/bot.php
+++ b/web/application/views/bot.php
@@ -5,6 +5,12 @@
 
     <div id="body">
         <p>This is the bot management page. Here you can configure and manage your bot.</p>
+
+        <div class="feature-box">
+            <h2>Bot Settings</h2>
+            <p>Configure your bot's token, webhook, and other settings.</p>
+            <a href="<?php echo site_url('settings'); ?>">Go to Settings</a>
+        </div>
     </div>
 </div>
 

--- a/web/application/views/settings.php
+++ b/web/application/views/settings.php
@@ -1,0 +1,36 @@
+<?php $this->load->view('partials/header'); ?>
+
+<div id="container">
+    <h1>Bot Settings</h1>
+
+    <div id="body">
+        <p>Use this page to configure your Telegram bot settings.</p>
+
+        <?php echo form_open('settings/update'); ?>
+
+        <div class="form-group">
+            <label for="bot_token">Bot Token</label>
+            <input type="text" name="bot_token" id="bot_token" class="form-control" value="<?php echo isset($config['BOT_TOKEN']) ? $config['BOT_TOKEN'] : ''; ?>" placeholder="Enter your Telegram Bot Token">
+        </div>
+
+        <div class="form-group">
+            <label for="webhook_url">Webhook URL</label>
+            <input type="text" name="webhook_url" id="webhook_url" class="form-control" value="<?php echo base_url('../bot.php'); ?>" placeholder="https://your.domain/path/to/bot.php">
+            <small class="form-text text-muted">The URL that Telegram will send updates to. This should point to the `bot.php` file in your project root.</small>
+        </div>
+
+        <div class="form-group">
+            <label for="public_channel_username">Public Channel Username</label>
+            <input type="text" name="public_channel_username" id="public_channel_username" class="form-control" value="<?php echo isset($config['PUBLIC_CHANNEL_USERNAME']) ? $config['PUBLIC_CHANNEL_USERNAME'] : ''; ?>" placeholder="your_public_channel_username">
+            <small class="form-text text-muted">The username of your public channel (without the @).</small>
+        </div>
+
+        <div class="form-group">
+            <button type="submit" class="btn btn-primary">Save Settings</button>
+        </div>
+
+        <?php echo form_close(); ?>
+    </div>
+</div>
+
+<?php $this->load->view('partials/footer'); ?>


### PR DESCRIPTION
This commit introduces a new settings page for the web dashboard to manage the Telegram bot's configuration.

Key changes include:
- A new settings page at `/settings` accessible to administrators.
- The page allows viewing and updating the bot token, webhook URL, and other configuration stored in `config/config.php`.
- Upon saving, the new webhook is automatically set via the Telegram API.
- Refactored the dashboard authentication to use PHP sessions instead of a hardcoded user ID, improving security and enabling proper multi-user support for the web panel.
- Created a `MY_Controller` to handle session management for all dashboard controllers.